### PR TITLE
Fixed crash when searching for games with bundles

### DIFF
--- a/core.py
+++ b/core.py
@@ -224,6 +224,9 @@ def parseDlcs(html):
     return games
 
 def getDlcs(storeUrl):
+    if "app/" not in storeUrl:
+        # edge case: 'https://store.steampowered.com/sub/516201/?snr=1_7_7_151_150_1'
+        return []
     appinfo = storeUrl.split("app/")[1].split("/")
     appid = appinfo[0]
     sanitazedName = appinfo[1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ altgraph==0.*
 beautifulsoup4==4.*
 certifi
 chardet==3.*
+cloudscraper==1.2.*
 future==0.*
 idna==2.*
 pefile
@@ -15,4 +16,3 @@ requests==2.*
 requests-toolbelt==0.*
 soupsieve==2.*
 urllib3==1.*
-cloudscraper==1.2.69

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ requests==2.*
 requests-toolbelt==0.*
 soupsieve==2.*
 urllib3==1.*
+cloudscraper==1.2.69


### PR DESCRIPTION
## Problem
When I search for games which have bundles / deluxe editions, the application crashes.

## Changes
- Added a guard which will prevent the crash of the app
- Added missing dependencies
